### PR TITLE
build(actions): update action versions to node.js 24

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/pull_erddap.yml
+++ b/.github/workflows/pull_erddap.yml
@@ -96,7 +96,7 @@ jobs:
 
       # Send email indicating if anything has changed
       - name: Send email
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v14
 
         with:
           server_address: smtp.gmail.com
@@ -108,7 +108,8 @@ jobs:
           subject: ERDDAP pull
           to: andrew.beet@noaa.gov
 
-          from: buoyData GitHub
+          from: 'buoyData GitHub <noreply@gmail.com>'
+          envelope_from: ${{ secrets.MAIL_USERNAME }}
 
           #body: file://${{github.workspace}}/data-raw/datapull.txt
 


### PR DESCRIPTION
## Justification

Node.js. 20 deprecated. All actions will be updated to meet Node.js 24 specs. The versions of these actions need to be updated in the workflows or they will fail after June 2, 2026

Waiting on `r-lib/actions` updates

fixes #30 

## Reviewers

None. Actions passing will be the review